### PR TITLE
add billingmode to dynamodb to fix deployment

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,7 @@ resources:
         KeySchema:
           - AttributeName: id
             KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
     RDSCluster:
       Type: AWS::RDS::DBCluster
       Properties:


### PR DESCRIPTION
The workflow is currently broken and fails with the message:
```
CREATE_FAILED: DDBTable (AWS::DynamoDB::Table)
An error occurred (ValidationException) when calling the CreateTable operation: No provisioned throughput specified for the table
```

It seems like we either need the `BillingMode` set to `PAY_PER_REQUEST` or add `ProvisionThroughPut` parameters.

