### PR TITLE
Update ddb.Scan.response.vlt file to resolve an error

### DIFF
--- a/templates/ddb.Scan.response.vlt
+++ b/templates/ddb.Scan.response.vlt
@@ -1,1 +1,1 @@
-$util.toJson($context.result)
+$util.toJson($context.result.items)


### PR DESCRIPTION
Making use of the `items` in the `$util.toJson($context.result.items)` resolved the issue with the error. 

The solution was proposed by a customer via [HubSpot](https://app-eu1.hubspot.com/contacts/26596507/record/0-5/3749314527).

After local testing, I was able to replicate the issue.

Current state:
```
Now trying to invoke the AppSync API for DynamoDB integration under http://localhost.localstack.cloud:4566/graphql/670e541f6b1e491780e477e76d.
{"data": {"addPostDDB": {"id": "id123"}}}Received notification message from WebSocket: {"addedPost": null}
{"data": {}, "errors": [{"message": "Expected Iterable, but did not find one for field 'Query.getPostsDDB'.", "locations": [{"line": 1, "column": 8}], "path": ["getPostsDDB"], "errorType": "GraphQLError"}]}Scanning items from DynamoDB table - should include entry with 'id123':
```

With the applied fix:
```
Now trying to invoke the AppSync API for DynamoDB integration under http://localhost.localstack.cloud:4566/graphql/0f4aced974e04b1692e05edae2.
{"data": {"addPostDDB": {"id": "id123"}}}Received notification message from WebSocket: {"addedPost": null}
{"data": {"getPostsDDB": [{"id": "id123"}]}}Scanning items from DynamoDB table - should include entry with 'id123':
{
  "Items": [
    {
      "id": {
        "S": "id123"
      }
    }
  ],
  "Count": 1,
  "ScannedCount": 1,
  "ConsumedCapacity": null
}
```